### PR TITLE
A few proposed tweaks to the dynamic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ hs_err_pid*
 build
 out
 target
+
+# Data
+*.csv

--- a/src/sugarWorld/Government.kt
+++ b/src/sugarWorld/Government.kt
@@ -14,7 +14,7 @@ class Government(var country: Country) : Consumer(bankBalance = country.populati
     fun step(t: Int) {
         log("Step $t:")
 
-        GDP = country.workforce.mostRecentWages
+        GDP = country.industry.salesThisStep
         var forecastedGDP = calculateForecastedGDP()
         previousGDP = GDP
 
@@ -37,7 +37,7 @@ class Government(var country: Country) : Consumer(bankBalance = country.populati
 
     private fun calculateTaxRate(govSpending: Double, expectedGDP: Double): Double {
         var desiredGovSurplus = 0.1 * (desiredReserves - bankBalance)
-        return Math.max((govSpending + desiredGovSurplus) / expectedGDP, 0.0)
+        return min(max((govSpending + desiredGovSurplus) / expectedGDP, 0.0), 1.0)
     }
 
     private fun calculateAmountToBuy(expectedGDP: Double): Double {
@@ -47,7 +47,7 @@ class Government(var country: Country) : Consumer(bankBalance = country.populati
     private fun calculateForecastedGDP(): Double {
         val gdpChange = GDP - previousGDP
         val forecastGDPChange = noTimestepsAheadToForecast * gdpChange
-        return GDP + forecastGDPChange
+        return max(GDP + forecastGDPChange, 0.0)
     }
 
     private fun log(msg: String) {

--- a/src/sugarWorld/Main.kt
+++ b/src/sugarWorld/Main.kt
@@ -3,10 +3,14 @@ package sugarWorld
 fun main(args : Array<String>) {
     val world = World(printLogs = false)
 
-    for(t in 1..100) {
+    for(t in 1..1000) {
         world.step(t)
         println("")
     }
 
-    world.writeGDPToCsv("results/gdp.csv")
+    world.writeDataToCsv(world.gdp, "results/gdp.csv")
+    world.writeDataToCsv(world.governmentBalance, "results/government_balance.csv")
+    world.writeDataToCsv(world.industryBalance, "results/industry_balance.csv")
+    world.writeDataToCsv(world.workforceBalance, "results/workforce_balance.csv")
+    world.writeDataToCsv(world.industryStock, "results/industry_stock.csv")
 }

--- a/src/sugarWorld/World.kt
+++ b/src/sugarWorld/World.kt
@@ -6,6 +6,10 @@ import java.io.FileWriter
 
 class World(val printLogs: Boolean = false) {
     val gdp = arrayListOf<ArrayList<Double>>()
+    val governmentBalance = arrayListOf<ArrayList<Double>>()
+    val industryBalance = arrayListOf<ArrayList<Double>>()
+    val workforceBalance = arrayListOf<ArrayList<Double>>()
+    val industryStock = arrayListOf<ArrayList<Double>>()
 
     val countries = arrayOf(
 //            Country(1, 12000, this, printLogs),
@@ -57,14 +61,16 @@ class World(val printLogs: Boolean = false) {
         return totalBought
     }
 
-    fun writeGDPToCsv(filePath: String) {
+    fun writeDataToCsv(data: ArrayList<ArrayList<Double>>, filePath: String) {
         val dir = File(filePath).parentFile
         if (!dir.exists()) {
             dir.mkdirs()
         }
 
         val writer = BufferedWriter(FileWriter(filePath))
-        gdp.forEach {
+        writer.write(countries.map { "country_${it.id}" }.joinToString())
+        writer.newLine()
+        data.forEach {
             writer.write(it.joinToString())
             writer.newLine()
         }
@@ -79,7 +85,19 @@ class World(val printLogs: Boolean = false) {
 
     private fun recordData() {
         val timestepGDP = arrayListOf<Double>()
+        val timestepGovernmentBalance = arrayListOf<Double>()
+        val timestepIndustryBalance = arrayListOf<Double>()
+        val timestepWorkforceBalance = arrayListOf<Double>()
+        val timestepIndustryStock = arrayListOf<Double>()
         countries.forEach { timestepGDP.add(it.industry.salesThisStep) }
+        countries.forEach { timestepGovernmentBalance.add(it.government.bankBalance) }
+        countries.forEach { timestepIndustryBalance.add(it.industry.bankBalance) }
+        countries.forEach { timestepWorkforceBalance.add(it.workforce.bankBalance) }
+        countries.forEach { timestepIndustryStock.add(it.industry.stock)}
         gdp.add(timestepGDP)
+        governmentBalance.add(timestepGovernmentBalance)
+        industryBalance.add(timestepIndustryBalance)
+        workforceBalance.add(timestepWorkforceBalance)
+        industryStock.add(timestepIndustryStock)
     }
 }


### PR DESCRIPTION
- Change GDP definition from `workforce.mostRecentWages` to `industry.SalesThisStep`. This seems more stable, e.g. `mostRecentWages` oscillates with increasing amplitude over time, as `industry.bankBalance` increases (since industry can spend all its balance on wages in a given timestep). Note that @joncoello83 was already using this definition when writing results.
- Smooth amount sold by industry by taking into account how much is left in stock. E.g., avoiding selling the entire stock in one go, and also allow shorting small amounts. This lets government actually buy some sugar, which was previously impossible in practice because workforce would act first and buy all sugar.
- Make labour deficit absolute rather than relative -- my guess is this was the intention, since it's passed through a logistic.
- Change the sign of the dependency between the proportion to save and the wealth change -- e.g. if wealth is decreasing save more in proportion, not less. This makes more sense to me?
- Other minor changes.

GDP over time:
![image](https://user-images.githubusercontent.com/40765518/44096766-f5ee61d4-9fd3-11e8-894f-547103770e5b.png)

Government balance:
![image](https://user-images.githubusercontent.com/40765518/44097033-b8a93604-9fd4-11e8-94cc-2f0278cc3a3b.png)


Industry balance:
![image](https://user-images.githubusercontent.com/40765518/44096817-11048e3a-9fd4-11e8-9d0f-c7bb49e60831.png)

Workforce balance:
![image](https://user-images.githubusercontent.com/40765518/44096963-89ead4d0-9fd4-11e8-83fb-1b5f60710f96.png)

